### PR TITLE
Workaround for eiger.file.sequence_id

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,7 +15,7 @@ jobs:
           # installation problems if out of date.
           python -m pip install --upgrade pip setuptools numpy
 
-          pip install black==19.10b
+          pip install black
       - name: Run black
         run: |
-          black . --check
+          black . --line-length=115 --check

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,4 +18,4 @@ jobs:
           pip install flake8
       - name: Run flake8
         run: |
-          flake8
+          flake8 --max-line-length=115

--- a/mxtools/__init__.py
+++ b/mxtools/__init__.py
@@ -2,3 +2,8 @@ from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions
+
+import datetime
+
+def print_now():
+    return datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S.%f')

--- a/mxtools/__init__.py
+++ b/mxtools/__init__.py
@@ -1,9 +1,10 @@
+import datetime
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions
 
-import datetime
 
 def print_now():
-    return datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S.%f')
+    return datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S.%f")

--- a/mxtools/_version.py
+++ b/mxtools/_version.py
@@ -247,7 +247,17 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(
-        GITS, ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix,], cwd=root,
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
     )
     # --long was added in git-1.5.5
     if describe_out is None:
@@ -289,7 +299,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix,)
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -4,10 +4,12 @@ from pathlib import PurePath
 from types import SimpleNamespace
 
 from ophyd import Component as Cpt
-from ophyd import Device, EpicsPathSignal, EpicsSignal, ImagePlugin, Signal, SingleTrigger
+from ophyd import (Device, EpicsPathSignal, EpicsSignal, ImagePlugin, Signal,
+                   SingleTrigger)
 from ophyd.areadetector import EigerDetector
 from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
-from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
+from ophyd.areadetector.filestore_mixins import \
+    FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
 # TODO: convert it to Enum class.
@@ -36,7 +38,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._datum_kwargs_map = dict()  # store kwargs for each uid
 
     def stage(self):
-        print('staging detector')
+        print("staging detector")
         res_uid = self.external_name.get()
         write_path = datetime.datetime.now().strftime(self.write_path_template)
         set_and_wait(self.file_path, f"{write_path}/")
@@ -48,7 +50,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._fn = fn
         res_kwargs = {"images_per_file": ipf}
         self._generate_resource(res_kwargs)
-        print('done staging detector')
+        print("done staging detector")
 
     def generate_datum(self, key, timestamp, datum_kwargs):
         # The detector keeps its own counter which is uses label HDF5
@@ -105,16 +107,16 @@ class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
 
     def read(self, *args, streaming=False, **kwargs):
         """
-            This is a test of using streaming read.
-            Ideally, this should be handled by a new _stream_attrs property.
-            For now, we just check for a streaming key in read and
-            call super() if False, or read the one key we know we should read
-            if True.
+        This is a test of using streaming read.
+        Ideally, this should be handled by a new _stream_attrs property.
+        For now, we just check for a streaming key in read and
+        call super() if False, or read the one key we know we should read
+        if True.
 
-            Parameters
-            ----------
-            streaming : bool, optional
-                whether to read streaming attrs or not
+        Parameters
+        ----------
+        streaming : bool, optional
+            whether to read streaming attrs or not
         """
         if streaming:
             key = self._image_name  # this comes from the SingleTrigger mixin
@@ -127,16 +129,16 @@ class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
 
     def describe(self, *args, streaming=False, **kwargs):
         """
-            This is a test of using streaming read.
-            Ideally, this should be handled by a new _stream_attrs property.
-            For now, we just check for a streaming key in read and
-            call super() if False, or read the one key we know we should read
-            if True.
+        This is a test of using streaming read.
+        Ideally, this should be handled by a new _stream_attrs property.
+        For now, we just check for a streaming key in read and
+        call super() if False, or read the one key we know we should read
+        if True.
 
-            Parameters
-            ----------
-            streaming : bool, optional
-                whether to read streaming attrs or not
+        Parameters
+        ----------
+        streaming : bool, optional
+            whether to read streaming attrs or not
         """
         if streaming:
             key = self._image_name  # this comes from the SingleTrigger mixin

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -4,10 +4,10 @@ from pathlib import PurePath
 from types import SimpleNamespace
 
 from ophyd import Component as Cpt
-from ophyd import Device, EpicsPathSignal, EpicsSignal, EpicsSignalRO, ImagePlugin, Signal, SingleTrigger
+from ophyd import Device, EpicsPathSignal, EpicsSignal, ImagePlugin, Signal, SingleTrigger
 from ophyd.areadetector import EigerDetector
 from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
-from ophyd.areadetector.filestore_mixins import FileStoreBase, new_short_uid
+from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
 

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -10,6 +10,7 @@ from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
 from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
+# TODO: convert it to Enum class.
 INTERNAL_SERIES = 0
 INTERNAL_ENABLE = 1
 EXTERNAL_SERIES = 2

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -10,6 +10,10 @@ from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
 from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
+INTERNAL_SERIES = 0
+INTERNAL_ENABLE = 1
+EXTERNAL_SERIES = 2
+EXTERNAL_ENABLE = 3
 
 class EigerSimulatedFilePlugin(Device, FileStoreBase):
     sequence_id = ADComponent(EpicsSignal, "SequenceId")
@@ -30,6 +34,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._datum_kwargs_map = dict()  # store kwargs for each uid
 
     def stage(self):
+        print('staging detector')
         res_uid = self.external_name.get()
         write_path = datetime.datetime.now().strftime(self.write_path_template)
         set_and_wait(self.file_path, f"{write_path}/")
@@ -41,6 +46,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._fn = fn
         res_kwargs = {"images_per_file": ipf}
         self._generate_resource(res_kwargs)
+        print('done staging detector')
 
     def generate_datum(self, key, timestamp, datum_kwargs):
         # The detector keeps its own counter which is uses label HDF5
@@ -82,7 +88,7 @@ class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # self.stage_sigs["cam.trigger_mode"] = 0 #original: single manual trigger
-        self.stage_sigs["cam.trigger_mode"] = 3
+        self.stage_sigs["cam.trigger_mode"] = EXTERNAL_SERIES
         self.stage_sigs.pop("cam.acquire")  # remove acquire=0
         # self.stage_sigs['shutter_mode'] = 1  # 'EPICS PV'
         self.stage_sigs.update({"cam.num_triggers": 1, "cam.compression_algo": "BS LZ4"})

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -4,12 +4,10 @@ from pathlib import PurePath
 from types import SimpleNamespace
 
 from ophyd import Component as Cpt
-from ophyd import (Device, EpicsPathSignal, EpicsSignal, ImagePlugin, Signal,
-                   SingleTrigger)
+from ophyd import Device, EpicsPathSignal, EpicsSignal, ImagePlugin, Signal, SingleTrigger
 from ophyd.areadetector import EigerDetector
 from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
-from ophyd.areadetector.filestore_mixins import \
-    FileStoreBase  # , new_short_uid
+from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
 # TODO: convert it to Enum class.

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -70,18 +70,20 @@ class EigerBaseV26(EigerDetector):
         # before parent
         ret = super().stage(*args, **kwargs)
         # after parent
-        set_and_wait(self.cam.manual_trigger, 1)
+        #set_and_wait(self.cam.manual_trigger, 1)
         return ret
 
     def unstage(self):
-        set_and_wait(self.cam.manual_trigger, 0)
+        #set_and_wait(self.cam.manual_trigger, 0)
         super().unstage()
 
 
 class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stage_sigs["cam.trigger_mode"] = 0
+        #self.stage_sigs["cam.trigger_mode"] = 0 #original: single manual trigger
+        self.stage_sigs["cam.trigger_mode"] = 3
+        self.stage_sigs.pop("cam.acquire") #remove acquire=0 
         # self.stage_sigs['shutter_mode'] = 1  # 'EPICS PV'
         self.stage_sigs.update({"cam.num_triggers": 1, "cam.compression_algo": "BS LZ4"})
 

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -70,20 +70,20 @@ class EigerBaseV26(EigerDetector):
         # before parent
         ret = super().stage(*args, **kwargs)
         # after parent
-        #set_and_wait(self.cam.manual_trigger, 1)
+        # set_and_wait(self.cam.manual_trigger, 1)
         return ret
 
     def unstage(self):
-        #set_and_wait(self.cam.manual_trigger, 0)
+        # set_and_wait(self.cam.manual_trigger, 0)
         super().unstage()
 
 
 class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        #self.stage_sigs["cam.trigger_mode"] = 0 #original: single manual trigger
+        # self.stage_sigs["cam.trigger_mode"] = 0 #original: single manual trigger
         self.stage_sigs["cam.trigger_mode"] = 3
-        self.stage_sigs.pop("cam.acquire") #remove acquire=0 
+        self.stage_sigs.pop("cam.acquire")  # remove acquire=0
         # self.stage_sigs['shutter_mode'] = 1  # 'EPICS PV'
         self.stage_sigs.update({"cam.num_triggers": 1, "cam.compression_algo": "BS LZ4"})
 

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -18,6 +18,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
     file_write_images_per_file = ADComponent(EpicsSignalWithRBV, "FWNImagesPerFile")
     current_run_start_uid = Cpt(Signal, value="", add_prefix=())
     enable = SimpleNamespace(get=lambda: True)
+    external_name = Cpt(Signal, value="")
 
     def __init__(self, *args, **kwargs):
         self.sequence_id_offset = 1
@@ -29,7 +30,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._datum_kwargs_map = dict()  # store kwargs for each uid
 
     def stage(self):
-        res_uid = new_short_uid()
+        res_uid = self.external_name.get()
         write_path = datetime.datetime.now().strftime(self.write_path_template)
         set_and_wait(self.file_path, f"{write_path}/")
         set_and_wait(self.file_write_name_pattern, "{}_$id".format(res_uid))

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -15,6 +15,7 @@ INTERNAL_ENABLE = 1
 EXTERNAL_SERIES = 2
 EXTERNAL_ENABLE = 3
 
+
 class EigerSimulatedFilePlugin(Device, FileStoreBase):
     sequence_id = ADComponent(EpicsSignal, "SequenceId")
     file_path = ADComponent(EpicsPathSignal, "FilePath", string=True, path_semantics="posix")

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -10,6 +10,8 @@ from ophyd.areadetector.base import ADComponent, EpicsSignalWithRBV
 from ophyd.areadetector.filestore_mixins import FileStoreBase  # , new_short_uid
 from ophyd.utils import set_and_wait
 
+from . import print_now
+
 # TODO: convert it to Enum class.
 INTERNAL_SERIES = 0
 INTERNAL_ENABLE = 1
@@ -36,7 +38,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._datum_kwargs_map = dict()  # store kwargs for each uid
 
     def stage(self):
-        print("staging detector")
+        print(f"{print_now()} staging detector {self.name}")
         res_uid = self.external_name.get()
         write_path = datetime.datetime.now().strftime(self.write_path_template)
         set_and_wait(self.file_path, f"{write_path}/")
@@ -48,7 +50,7 @@ class EigerSimulatedFilePlugin(Device, FileStoreBase):
         self._fn = fn
         res_kwargs = {"images_per_file": ipf}
         self._generate_resource(res_kwargs)
-        print("done staging detector")
+        print(f"{print_now()} done staging detector {self.name}")
 
     def generate_datum(self, key, timestamp, datum_kwargs):
         # The detector keeps its own counter which is uses label HDF5
@@ -66,7 +68,7 @@ class EigerBaseV26(EigerDetector):
     file = Cpt(
         EigerSimulatedFilePlugin,
         suffix="cam1:",
-        write_path_template="/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/",
+        write_path_template="/GPFS/CENTRAL/xf17id2/jaishima/20210817_ophyd_bluesky/",
         root="/GPFS/CENTRAL/xf17id2",
     )
     image = Cpt(ImagePlugin, "image1:")

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -24,7 +24,7 @@ class MXFlyer:
         self._collection_dictionary = None
 
     def kickoff(self):
-
+        self.detector.stage()
         self.vector.go.put(1)
 
         return NullStatus()
@@ -62,7 +62,7 @@ class MXFlyer:
             yield item
 
     def unstage(self):
-        ...
+        self.detector.unstage()
 
 
 def configure_flyer(
@@ -123,9 +123,12 @@ def configure_nyx_flyer():
     ...
 
 
-def actual_scan(mx_flyer, vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage):
+def actual_scan(mx_flyer, eiger, vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage):
+    file_prefix = "abc"
+    data_directory_name = "def"
+    yield from bps.mv(eiger.file.external_name, 'prefix_name')
     yield from configure_flyer(
-        vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage, "abc", "abc", 1,
+        vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage, file_prefix, data_directory_name, 1,
     )
     yield from bp.fly([mx_flyer])
 

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -6,7 +6,8 @@ from bluesky import plans as bp
 from ophyd.sim import NullStatus
 from ophyd.status import SubscriptionStatus
 
-from .scans import setup_vector_program, setup_zebra_vector_scan, zebra_daq_prep
+from .scans import (setup_vector_program, setup_zebra_vector_scan,
+                    zebra_daq_prep)
 
 
 class MXFlyer:

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -6,8 +6,7 @@ from bluesky import plans as bp
 from ophyd.sim import NullStatus
 from ophyd.status import SubscriptionStatus
 
-from .scans import (setup_vector_program, setup_zebra_vector_scan,
-                    zebra_daq_prep)
+from .scans import setup_vector_program, setup_zebra_vector_scan, zebra_daq_prep
 
 
 class MXFlyer:

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -126,9 +126,17 @@ def configure_nyx_flyer():
 def actual_scan(mx_flyer, eiger, vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage):
     file_prefix = "abc"
     data_directory_name = "def"
-    yield from bps.mv(eiger.file.external_name, 'prefix_name')
+    yield from bps.mv(eiger.file.external_name, "prefix_name")
     yield from configure_flyer(
-        vector, zebra, angle_start, scanWidth, imgWidth, exposurePeriodPerImage, file_prefix, data_directory_name, 1,
+        vector,
+        zebra,
+        angle_start,
+        scanWidth,
+        imgWidth,
+        exposurePeriodPerImage,
+        file_prefix,
+        data_directory_name,
+        1,
     )
     yield from bp.fly([mx_flyer])
 

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -68,6 +68,7 @@ class MXFlyer:
 def configure_flyer(
     vector,
     zebra,
+    eiger_single,
     angle_start,
     scanWidth,
     imgWidth,
@@ -92,7 +93,7 @@ def configure_flyer(
     else:
         yield from bps.mv(vector.buffer_time, 3)
         pass
-    detector_dead_time = 0.001  # TODO get real dead time from detector object
+    detector_dead_time = eiger_single.cam.dead_time.get()
     yield from setup_vector_program(
         vector=vector,
         num_images=numImages,
@@ -130,6 +131,7 @@ def actual_scan(mx_flyer, eiger, vector, zebra, angle_start, scanWidth, imgWidth
     yield from configure_flyer(
         vector,
         zebra,
+        eiger,
         angle_start,
         scanWidth,
         imgWidth,

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -1,11 +1,12 @@
 import getpass
 import grp
 import logging
-from mxtools.eiger import EXTERNAL_SERIES
 import os
 import time
 
 import bluesky.plan_stubs as bps
+
+from mxtools.eiger import EXTERNAL_SERIES
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,10 @@ def setup_zebra_vector_scan_for_raster(
     yield from bps.mv(zebra.pc.gate.start, angle_start)
     if image_width != 0:
         yield from bps.mv(
-            zebra.pc.gate.width, num_images * image_width, zebra.pc.gate.step, num_images * image_width + 0.01,
+            zebra.pc.gate.width,
+            num_images * image_width,
+            zebra.pc.gate.step,
+            num_images * image_width + 0.01,
         )
     yield from bps.mv(
         zebra.pc.gate.num_gates,
@@ -85,7 +89,8 @@ def setup_vector_program(vector, num_images, angle_start, angle_end, exposure_pe
         vector.end.omega,
         angle_end,
         vector.frame_exptime,
-        exposure_period_per_image * 1000.0)
+        exposure_period_per_image * 1000.0,
+    )
     yield from bps.mv(vector.hold, 0)
 
 

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -133,7 +133,9 @@ def setup_eiger_arming(
     yield from bps.mv(eiger.cam.num_images, num_images)
     yield from bps.mv(eiger.cam.file_path, data_directory_name)
     yield from bps.mv(eiger.cam.fw_name_pattern, f"{file_prefix_minus_directory}_$id")
-    yield from bps.mv(eiger.cam.sequence_id, file_number_start)
+
+    # TODO: change it back to eiger.cam.sequence_id once the ophyd PR https://github.com/bluesky/ophyd/pull/1001 is merged/released.
+    yield from bps.mv(eiger.file.sequence_id, file_number_start)
 
     # originally from detector_set_fileheader
     yield from bps.mv(eiger.cam.beam_center_x, x_beam)

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -159,6 +159,7 @@ def setup_eiger_stop_acquire_and_wait(eiger):
 
 
 # use it as follows:
-# RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210729', '/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/', 2851, 2002.125, 2245.850, 0.9793, 0.250))
+# RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210729',\
+#    '/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/', 2851, 2002.125, 2245.850, 0.9793, 0.250))
 # RE(actual_scan(mx_flyer, eiger_single, vector, zebra, 0, 100, 0.2, 0.01))
 # and it should all work - but doesn't at the moment (Eiger not getting triggered)

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -134,7 +134,8 @@ def setup_eiger_arming(
     yield from bps.mv(eiger.cam.file_path, data_directory_name)
     yield from bps.mv(eiger.cam.fw_name_pattern, f"{file_prefix_minus_directory}_$id")
 
-    # TODO: change it back to eiger.cam.sequence_id once the ophyd PR https://github.com/bluesky/ophyd/pull/1001 is merged/released.
+    # TODO: change it back to eiger.cam.sequence_id once the ophyd PR
+    # https://github.com/bluesky/ophyd/pull/1001 is merged/released.
     yield from bps.mv(eiger.file.sequence_id, file_number_start)
 
     # originally from detector_set_fileheader

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -28,7 +28,7 @@ def setup_zebra_vector_scan(
     num_images,
     is_still=False,
 ):
-    yield from bps.mv(zebra.pc.gate.sel, angle_start)
+    yield from bps.mv(zebra.pc.gate.start, angle_start)
     if is_still is False:
         yield from bps.mv(zebra.pc.gate.width, gate_width, zebra.pc.gate.step, scan_width)
     yield from bps.mv(
@@ -121,6 +121,8 @@ def setup_eiger_arming(
     wavelength,
     det_distance_m,
 ):
+    yield from bps.mv(eiger.cam.trigger_mode, 3)
+
     yield from bps.mv(eiger.cam.save_files, 1)
     yield from bps.mv(eiger.cam.file_owner, getpass.getuser())
     yield from bps.mv(eiger.cam.file_owner_grp, grp.getgrgid(os.getgid())[0])
@@ -154,3 +156,8 @@ def setup_eiger_arming(
 def setup_eiger_stop_acquire_and_wait(eiger):
     yield from bps.mv(eiger.cam.acquire, 0)
     # wait until Acquire_RBV is 0
+
+# use it as follows:
+#RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210729', '/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/', 2851, 2002.125, 2245.850, 0.9793, 0.250))
+#RE(actual_scan(mx_flyer, eiger_single, vector, zebra, 0, 100, 0.2, 0.01))
+#and it should all work - but doesn't at the moment (Eiger not getting triggered)

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -18,7 +18,7 @@ def zebra_daq_prep(zebra):
     yield from bps.mv(zebra.m1_set_pos, 1)
     yield from bps.mv(zebra.m2_set_pos, 1)
     yield from bps.mv(zebra.m3_set_pos, 1)
-    yield from bps.mv(zebra.pc.arm_sel, 1)
+    yield from bps.mv(zebra.pc.arm.trig_source, 1)
 
 
 def setup_zebra_vector_scan(

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -1,6 +1,7 @@
 import getpass
 import grp
 import logging
+from mxtools.eiger import EXTERNAL_ENABLE, EXTERNAL_SERIES
 import os
 import time
 
@@ -12,9 +13,11 @@ logger = logging.getLogger(__name__)
 def zebra_daq_prep(zebra):
     yield from bps.mv(zebra.reset, 1)
     yield from bps.sleep(2.0)
-    yield from bps.mv(
-        zebra.out1, 31, zebra.m1_set_pos, 1, zebra.m2_set_pos, 1, zebra.m3_set_pos, 1, zebra.pc.arm_sel, 1,
-    )
+    yield from bps.mv(zebra.out1, 31)
+    yield from bps.mv(zebra.m1_set_pos, 1)
+    yield from bps.mv(zebra.m2_set_pos, 1)
+    yield from bps.mv(zebra.m3_set_pos, 1)
+    yield from bps.mv(zebra.pc.arm_sel, 1)
 
 
 def setup_zebra_vector_scan(
@@ -31,20 +34,12 @@ def setup_zebra_vector_scan(
     yield from bps.mv(zebra.pc.gate.start, angle_start)
     if is_still is False:
         yield from bps.mv(zebra.pc.gate.width, gate_width, zebra.pc.gate.step, scan_width)
-    yield from bps.mv(
-        zebra.pc.gate.num_gates,
-        1,
-        zebra.pc.pulse.start,
-        0,
-        zebra.pc.pulse.width,
-        pulse_width,
-        zebra.pc.pulse.step,
-        pulse_step,
-        zebra.pc.pulse.delay,
-        exposure_period_per_image / 2 * 1000,
-        zebra.pc.pulse.max,
-        num_images,
-    )
+    yield from bps.mv(zebra.pc.gate.num_gates, 1)
+    yield from bps.mv(zebra.pc.pulse.start, 0)
+    yield from bps.mv(zebra.pc.pulse.width, pulse_width)
+    yield from bps.mv(zebra.pc.pulse.step, pulse_step)
+    yield from bps.mv(zebra.pc.pulse.delay, exposure_period_per_image / 2 * 1000)
+    yield from bps.mv(zebra.pc.pulse.max, num_images)
 
 
 def setup_zebra_vector_scan_for_raster(
@@ -90,10 +85,8 @@ def setup_vector_program(vector, num_images, angle_start, angle_end, exposure_pe
         vector.end.omega,
         angle_end,
         vector.frame_exptime,
-        exposure_period_per_image * 1000.0,
-        vector.hold,
-        0,
-    )
+        exposure_period_per_image * 1000.0)
+    yield from bps.mv(vector.hold, 0)
 
 
 def setup_eiger_exposure(eiger, exposure_time, exposure_period):
@@ -121,7 +114,7 @@ def setup_eiger_arming(
     wavelength,
     det_distance_m,
 ):
-    yield from bps.mv(eiger.cam.trigger_mode, 3)
+    yield from bps.mv(eiger.cam.trigger_mode, EXTERNAL_SERIES)
 
     yield from bps.mv(eiger.cam.save_files, 1)
     yield from bps.mv(eiger.cam.file_owner, getpass.getuser())

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -157,7 +157,8 @@ def setup_eiger_stop_acquire_and_wait(eiger):
     yield from bps.mv(eiger.cam.acquire, 0)
     # wait until Acquire_RBV is 0
 
+
 # use it as follows:
-#RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210729', '/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/', 2851, 2002.125, 2245.850, 0.9793, 0.250))
-#RE(actual_scan(mx_flyer, eiger_single, vector, zebra, 0, 100, 0.2, 0.01))
-#and it should all work - but doesn't at the moment (Eiger not getting triggered)
+# RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210729', '/GPFS/CENTRAL/xf17id2/mfuchs/fmxoperator/20200222/mx999999-1665/', 2851, 2002.125, 2245.850, 0.9793, 0.250))
+# RE(actual_scan(mx_flyer, eiger_single, vector, zebra, 0, 100, 0.2, 0.01))
+# and it should all work - but doesn't at the moment (Eiger not getting triggered)

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -1,7 +1,7 @@
 import getpass
 import grp
 import logging
-from mxtools.eiger import EXTERNAL_ENABLE, EXTERNAL_SERIES
+from mxtools.eiger import EXTERNAL_SERIES
 import os
 import time
 

--- a/mxtools/zebra.py
+++ b/mxtools/zebra.py
@@ -1,3 +1,5 @@
+import time as ttime
+
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd.signal import Signal
@@ -22,35 +24,46 @@ class ZebraPCPulse(ZebraPCBase):
 
 
 class ZebraPCArm(Device):
-    trig_source = Cpt(EpicsSignal, write_pv="SEL", read_pv="SEL:RBV",
-                      kind="omitted", auto_monitor=True, add_prefix=("write_pv", "read_pv"),
-                      doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_SEL")
-    arm_status = Cpt(EpicsSignalRO, "INP:STA", kind="omitted", auto_monitor=True,
-                     doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA")
+    trig_source = Cpt(
+        EpicsSignal,
+        write_pv="SEL",
+        read_pv="SEL:RBV",
+        kind="omitted",
+        auto_monitor=True,
+        add_prefix=("write_pv", "read_pv"),
+        doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_SEL",
+    )
+    arm_status = Cpt(
+        EpicsSignalRO,
+        "INP:STA",
+        kind="omitted",
+        auto_monitor=True,
+        doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA",
+    )
     output = Cpt(EpicsSignalRO, "OUT", kind="omitted", auto_monitor=True)
     # This is handled by vector.go(...), so we don't need the 'arm' component.
     # arm = Cpt(EpicsSignal, "", kind="normal", auto_monitor=True)
-    # Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA   
+    # Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA
 
 
 class ZebraPositionCaptureData(Device):
-    num_captured = Cpt(EpicsSignalRO, 'NUM_CAP', kind="normal")
-    num_downloaded = Cpt(EpicsSignalRO, 'NUM_DOWN', kind="normal")
+    num_captured = Cpt(EpicsSignalRO, "NUM_CAP", kind="normal")
+    num_downloaded = Cpt(EpicsSignalRO, "NUM_DOWN", kind="normal")
 
-    time = Cpt(EpicsSignalRO, 'TIME', kind="normal")
+    time = Cpt(EpicsSignalRO, "TIME", kind="normal")
 
-    enc1 = Cpt(EpicsSignalRO, 'ENC1', kind="omitted")
-    enc2 = Cpt(EpicsSignalRO, 'ENC2', kind="omitted")
-    enc3 = Cpt(EpicsSignalRO, 'ENC3', kind="omitted")
-    enc4 = Cpt(EpicsSignalRO, 'ENC4', kind="normal")
+    enc1 = Cpt(EpicsSignalRO, "ENC1", kind="omitted")
+    enc2 = Cpt(EpicsSignalRO, "ENC2", kind="omitted")
+    enc3 = Cpt(EpicsSignalRO, "ENC3", kind="omitted")
+    enc4 = Cpt(EpicsSignalRO, "ENC4", kind="normal")
 
-    sys1 = Cpt(EpicsSignalRO, 'SYS1', kind="omitted")
-    sys2 = Cpt(EpicsSignalRO, 'SYS2', kind="omitted")
+    sys1 = Cpt(EpicsSignalRO, "SYS1", kind="omitted")
+    sys2 = Cpt(EpicsSignalRO, "SYS2", kind="omitted")
 
-    div1 = Cpt(EpicsSignalRO, 'DIV1', kind="omitted")
-    div2 = Cpt(EpicsSignalRO, 'DIV2', kind="omitted")
-    div3 = Cpt(EpicsSignalRO, 'DIV3', kind="omitted")
-    div4 = Cpt(EpicsSignalRO, 'DIV4', kind="omitted")
+    div1 = Cpt(EpicsSignalRO, "DIV1", kind="omitted")
+    div2 = Cpt(EpicsSignalRO, "DIV2", kind="omitted")
+    div3 = Cpt(EpicsSignalRO, "DIV3", kind="omitted")
+    div4 = Cpt(EpicsSignalRO, "DIV4", kind="omitted")
 
 
 class ZebraPositionCompare(Device):
@@ -58,10 +71,9 @@ class ZebraPositionCompare(Device):
     # arm_status = Cpt(EpicsSignalRO, "ARM_INP.STA", kind="omitted")
     # arm_sel = Cpt(EpicsSignal, "ARM_SEL", kind="omitted")
     download_count = Cpt(EpicsSignalRO, "NUM_DOWN", kind="omitted")
-    
+
     arm_signal = Cpt(EpicsSignal, "ARM", kind="omitted")
-    disarm = Cpt(EpicsSignal, "DISARM", kind="omitted",
-                 doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_DISARM")
+    disarm = Cpt(EpicsSignal, "DISARM", kind="omitted", doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_DISARM")
 
     encoder = Cpt(EpicsSignal, "ENC", kind="config", auto_monitor=True)
     enc_x = Cpt(EpicsSignal, "ENC1", kind="omitted")
@@ -81,7 +93,7 @@ class ZebraAnd(Device):
 
 
 class Zebra(Device):
-    download_status = Cpt(EpicsSignalRO, 'ARRAY_ACQ', kind="omitted")
+    download_status = Cpt(EpicsSignalRO, "ARRAY_ACQ", kind="omitted")
     reset = Cpt(EpicsSignal, "SYS_RESET.PROC", kind="omitted")
     m1_set_pos = Cpt(EpicsSignal, "M1:SETPOS.PROC", kind="omitted")
     m2_set_pos = Cpt(EpicsSignal, "M2:SETPOS.PROC", kind="omitted")
@@ -94,11 +106,10 @@ class Zebra(Device):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        formatted_to_be_normal = [f"{self.pc.data.name}_enc{num}"
-                                  for num in self.enc_of_interest.get()]
+        formatted_to_be_normal = [f"{self.pc.data.name}_enc{num}" for num in self.enc_of_interest.get()]
         for cpt in self.pc.data.component_names:
             cpt_obj = getattr(self.pc.data, cpt)
-            if 'enc' in cpt:
+            if "enc" in cpt:
                 if cpt_obj.name in formatted_to_be_normal:
                     cpt_obj.kind = "normal"
                 else:
@@ -118,7 +129,7 @@ class Zebra(Device):
 
         disarmed_signal = self.download_status
 
-        self._collection_ts = time.time()
+        self._collection_ts = ttime.time()
 
         def armed_status_cb(value, old_value, obj, **kwargs):
             if int(old_value) == 0 and int(value) == 1:
@@ -148,25 +159,27 @@ class Zebra(Device):
 
         # Arrays of captured positions
         data = {
-            f'enc{i}': getattr(pc.data, f'enc{i}').get()
-                for i in self.enc_of_interest.get()
-                if getattr(pc, f'capture_enc{i}').get()
+            f"enc{i}": getattr(pc.data, f"enc{i}").get()
+            for i in self.enc_of_interest.get()
+            if getattr(pc, f"capture_enc{i}").get()
         }
 
         for i, timestamp in enumerate(ts):
             yield {
-                'data': { k: v[i] for k, v in data.items() },
-                'timestamps': { k: timestamp for k in data.keys() },
-                'time' : timestamp
+                "data": {k: v[i] for k, v in data.items()},
+                "timestamps": {k: timestamp for k in data.keys()},
+                "time": timestamp,
             }
 
     def describe_collect(self):
         return {
-            'primary': {
-                f'enc{i}': {
-                    'source': 'PV:' + getattr(self.pc.data, f'enc{i}').pvname,
-                    'shape': [],
-                    'dtype': 'number'
-                } for i in self.enc_of_interest.get() if getattr(self.pc, f'capture_enc{i}').get()
+            "primary": {
+                f"enc{i}": {
+                    "source": "PV:" + getattr(self.pc.data, f"enc{i}").pvname,
+                    "shape": [],
+                    "dtype": "number",
+                }
+                for i in self.enc_of_interest.get()
+                if getattr(self.pc, f"capture_enc{i}").get()
             }
         }

--- a/mxtools/zebra.py
+++ b/mxtools/zebra.py
@@ -1,5 +1,7 @@
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
+from ophyd.signal import Signal
+from ophyd.status import DeviceStatus
 
 
 class ZebraPCBase(Device):
@@ -16,14 +18,51 @@ class ZebraPCGate(ZebraPCBase):
 class ZebraPCPulse(ZebraPCBase):
     max = Cpt(EpicsSignal, "MAX", kind="config", auto_monitor=True)
     delay = Cpt(EpicsSignal, "DLY", kind="config", auto_monitor=True)
-    status = Cpt(EpicsSignalRO, "INP.STA", kind="omitted")
+    # status = Cpt(EpicsSignalRO, "INP.STA", kind="omitted")
+
+
+class ZebraPCArm(Device):
+    trig_source = Cpt(EpicsSignal, write_pv="SEL", read_pv="SEL:RBV",
+                      kind="omitted", auto_monitor=True, add_prefix=("write_pv", "read_pv"),
+                      doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_SEL")
+    arm_status = Cpt(EpicsSignalRO, "INP:STA", kind="omitted", auto_monitor=True,
+                     doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA")
+    output = Cpt(EpicsSignalRO, "OUT", kind="omitted", auto_monitor=True)
+    # This is handled by vector.go(...), so we don't need the 'arm' component.
+    # arm = Cpt(EpicsSignal, "", kind="normal", auto_monitor=True)
+    # Example: XF:17IDC-ES:FMX{Zeb:3}:PC_ARM_INP:STA   
+
+
+class ZebraPositionCaptureData(Device):
+    num_captured = Cpt(EpicsSignalRO, 'NUM_CAP', kind="normal")
+    num_downloaded = Cpt(EpicsSignalRO, 'NUM_DOWN', kind="normal")
+
+    time = Cpt(EpicsSignalRO, 'TIME', kind="normal")
+
+    enc1 = Cpt(EpicsSignalRO, 'ENC1', kind="omitted")
+    enc2 = Cpt(EpicsSignalRO, 'ENC2', kind="omitted")
+    enc3 = Cpt(EpicsSignalRO, 'ENC3', kind="omitted")
+    enc4 = Cpt(EpicsSignalRO, 'ENC4', kind="normal")
+
+    sys1 = Cpt(EpicsSignalRO, 'SYS1', kind="omitted")
+    sys2 = Cpt(EpicsSignalRO, 'SYS2', kind="omitted")
+
+    div1 = Cpt(EpicsSignalRO, 'DIV1', kind="omitted")
+    div2 = Cpt(EpicsSignalRO, 'DIV2', kind="omitted")
+    div3 = Cpt(EpicsSignalRO, 'DIV3', kind="omitted")
+    div4 = Cpt(EpicsSignalRO, 'DIV4', kind="omitted")
 
 
 class ZebraPositionCompare(Device):
-    arm_status = Cpt(EpicsSignalRO, "ARM_INP.STA", kind="omitted")
-    arm_sel = Cpt(EpicsSignal, "ARM_SEL", kind="omitted")
+    arm = Cpt(ZebraPCArm, "ARM_", kind="omitted")
+    # arm_status = Cpt(EpicsSignalRO, "ARM_INP.STA", kind="omitted")
+    # arm_sel = Cpt(EpicsSignal, "ARM_SEL", kind="omitted")
     download_count = Cpt(EpicsSignalRO, "NUM_DOWN", kind="omitted")
-    disarm = Cpt(EpicsSignal, "DISARM", kind="omitted")
+    
+    arm_signal = Cpt(EpicsSignal, "ARM", kind="omitted")
+    disarm = Cpt(EpicsSignal, "DISARM", kind="omitted",
+                 doc="Example: XF:17IDC-ES:FMX{Zeb:3}:PC_DISARM")
+
     encoder = Cpt(EpicsSignal, "ENC", kind="config", auto_monitor=True)
     enc_x = Cpt(EpicsSignal, "ENC1", kind="omitted")
     enc_y = Cpt(EpicsSignal, "ENC2", kind="omitted")
@@ -33,6 +72,7 @@ class ZebraPositionCompare(Device):
     gate = Cpt(ZebraPCGate, "GATE_", kind="config")
     pulse = Cpt(ZebraPCPulse, "PULSE_")
     time = Cpt(EpicsSignalRO, "TIME", kind="omitted")
+    data = Cpt(ZebraPositionCaptureData, "", kind="normal")
 
 
 class ZebraAnd(Device):
@@ -41,7 +81,7 @@ class ZebraAnd(Device):
 
 
 class Zebra(Device):
-    downloading = Cpt(EpicsSignal, "ARRAY_ACQ", kind="omitted")
+    download_status = Cpt(EpicsSignalRO, 'ARRAY_ACQ', kind="omitted")
     reset = Cpt(EpicsSignal, "SYS_RESET.PROC", kind="omitted")
     m1_set_pos = Cpt(EpicsSignal, "M1:SETPOS.PROC", kind="omitted")
     m2_set_pos = Cpt(EpicsSignal, "M2:SETPOS.PROC", kind="omitted")
@@ -50,3 +90,83 @@ class Zebra(Device):
     out1 = Cpt(EpicsSignal, "OUT1_TTL", kind="config", auto_monitor=True)
     pc = Cpt(ZebraPositionCompare, "PC_")
     and1 = Cpt(ZebraAnd, "AND1_")
+    enc_of_interest = Cpt(Signal, value=[4], kind="config")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        formatted_to_be_normal = [f"{self.pc.data.name}_enc{num}"
+                                  for num in self.enc_of_interest.get()]
+        for cpt in self.pc.data.component_names:
+            cpt_obj = getattr(self.pc.data, cpt)
+            if 'enc' in cpt:
+                if cpt_obj.name in formatted_to_be_normal:
+                    cpt_obj.kind = "normal"
+                else:
+                    cpt_obj.kind = "omitted"
+
+    def kickoff(self):
+        armed_status = DeviceStatus(self)
+        self._disarmed_status = disarmed_status = DeviceStatus(self)
+
+        pc = self.pc
+        external = pc.arm.trig_source.get(as_string=True) == "External"  # Using external trigger?
+
+        if external:
+            armed_signal = pc.arm.arm_status
+        else:
+            armed_signal = pc.arm.output
+
+        disarmed_signal = self.download_status
+
+        self._collection_ts = time.time()
+
+        def armed_status_cb(value, old_value, obj, **kwargs):
+            if int(old_value) == 0 and int(value) == 1:
+                armed_status._finished()
+                obj.clear_sub(armed_status_cb)
+
+        def disarmed_status_cb(value, old_value, obj, **kwargs):
+            # I'm getting a stale 1 -> 0 update, so use timestamps to filter that out
+            if int(old_value) == 1 and int(value) == 0:
+                disarmed_status._finished()
+                obj.clear_sub(disarmed_status_cb)
+
+        armed_signal.subscribe(armed_status_cb, run=False)
+        disarmed_signal.subscribe(disarmed_status_cb, run=False)
+
+        # Arm it if not External
+        if not external:
+            self.pc.arm_signal.put(1)
+
+        return armed_status
+
+    def collect(self):
+        pc = self.pc
+
+        # Array of timestamps
+        ts = pc.data.time.get() + self._collection_ts
+
+        # Arrays of captured positions
+        data = {
+            f'enc{i}': getattr(pc.data, f'enc{i}').get()
+                for i in self.enc_of_interest.get()
+                if getattr(pc, f'capture_enc{i}').get()
+        }
+
+        for i, timestamp in enumerate(ts):
+            yield {
+                'data': { k: v[i] for k, v in data.items() },
+                'timestamps': { k: timestamp for k in data.keys() },
+                'time' : timestamp
+            }
+
+    def describe_collect(self):
+        return {
+            'primary': {
+                f'enc{i}': {
+                    'source': 'PV:' + getattr(self.pc.data, f'enc{i}').pvname,
+                    'shape': [],
+                    'dtype': 'number'
+                } for i in self.enc_of_interest.get() if getattr(self.pc, f'capture_enc{i}').get()
+            }
+        }


### PR DESCRIPTION
See https://github.com/bluesky/ophyd/pull/1001 for a proper fix.

IPython history:
```py
In [1]: %history ~1/
RE(setup_eiger_arming(eiger_single, 0, 100, 10, 0.01, 'test20210723', '/GPFS/CENTRAL/xf17id2/FMX-999999_20Jul2021', 2851, 2002.125, 2245.850, 0.9793, 0.250))
eiger_single.file.external_name.get()
eiger_single.file.file_path
eiger_single.file.file_path.get()
eiger_single.file.file_write_name_pattern
eiger_single.file.file_write_name_pattern.get()
eiger_single.file.external_name.put(eiger_single.file.file_write_name_pattern.get())
eiger_single.file.external_name.get()
eiger_single.stage()
```