### PR TITLE
Flyer more generic lsdc 133

### DIFF
--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -170,19 +170,15 @@ class MXFlyer:
 
 def configure_flyer(
     vector,
-    detector_single,
     angle_start,
     scanWidth,
     imgWidth,
     exposurePeriodPerImage,
     filePrefix,
-    data_directory_name,
     file_number_start,
     scanEncoder=3,
     changeState=True,
 ):  # scan encoder 0=x, 1=y,2=z,3=omega
-
-    detector_single.file.write_path_template = data_directory_name
 
     yield from bps.mv(vector.sync, 1)
     yield from bps.mv(vector.expose, 1)
@@ -247,16 +243,15 @@ def actual_scan(
     # file_prefix = "abc"
     # data_directory_name = "def"
     yield from bps.mv(detector.file.external_name, file_prefix)
+    detector_single.file.write_path_template = data_directory_name
     detector_dead_time = detector_single.cam.dead_time.get()
     yield from configure_flyer(
         vector,
-        detector,
         angle_start,
         scanWidth,
         imgWidth,
         exposurePeriodPerImage,
         file_prefix,
-        data_directory_name,
         1,
     )
     yield from configure_zebra(

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -208,6 +208,8 @@ def configure_flyer(
         angle_end=angle_end,
         exposure_period_per_image=exposurePeriodPerImage,
     )
+
+def configure_zebra(zebra, angle_start, exposurePeriodPerImage, detector_dead_time, scanWidth, imgWidth, numImages)
     yield from zebra_daq_prep(zebra)
     yield from bps.sleep(1.0)
 

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -183,7 +183,6 @@ def configure_vector(
     scanWidth,
     imgWidth,
     exposurePeriodPerImage,
-    filePrefix,
     file_number_start,
     scanEncoder=3,
     changeState=True,
@@ -264,7 +263,6 @@ def actual_scan(
         scanWidth,
         imgWidth,
         exposurePeriodPerImage,
-        file_prefix,
         1,
     )
     yield from configure_zebra(

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -168,7 +168,7 @@ class MXFlyer:
         self.detector.cam.acquire.put(0)
 
 
-def configure_flyer(
+def configure_vector(
     vector,
     angle_start,
     scanWidth,
@@ -245,7 +245,7 @@ def actual_scan(
     yield from bps.mv(detector.file.external_name, file_prefix)
     detector_single.file.write_path_template = data_directory_name
     detector_dead_time = detector_single.cam.dead_time.get()
-    yield from configure_flyer(
+    yield from configure_vector(
         vector,
         angle_start,
         scanWidth,

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -168,6 +168,15 @@ class MXFlyer:
         self.detector.cam.acquire.put(0)
 
 
+def configure_detector(
+    detector,
+    file_prefix,
+    data_directory_name
+):
+    yield from bps.mv(detector.file.external_name, file_prefix)
+    detector.file.write_path_template = data_directory_name
+ 
+
 def configure_vector(
     vector,
     angle_start,
@@ -243,8 +252,11 @@ def actual_scan(
     # file_prefix = "abc"
     # data_directory_name = "def"
 
-    yield from bps.mv(detector.file.external_name, file_prefix)
-    detector.file.write_path_template = data_directory_name
+    yield from configure_detector(
+        detector,
+        file_prefix,
+        data_directory_name
+    )
     detector_dead_time = detector.cam.dead_time.get()
     yield from configure_vector(
         vector,

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -14,11 +14,11 @@ DEFAULT_DATUM_DICT = {"data": None, "omega": None}
 
 
 class MXFlyer:
-    def __init__(self, vector, zebra, eiger=None) -> None:
+    def __init__(self, vector, zebra, detector=None) -> None:
         self.name = "MXFlyer"
         self.vector = vector
         self.zebra = zebra
-        self.detector = eiger
+        self.detector = detector
 
         self._asset_docs_cache = deque()
         self._resource_uids = []
@@ -145,7 +145,7 @@ class MXFlyer:
         #     ...: ...,
         # }
 
-        # event = {...: ..., "data": {"eiger_img": "a", "omega": "b"}}
+        # event = {...: ..., "data": {"detector_img": "a", "omega": "b"}}
 
         for data_key in self._datum_ids.keys():
             datum_id = f"{resource_uid}/{data_key}"
@@ -171,7 +171,7 @@ class MXFlyer:
 def configure_flyer(
     vector,
     zebra,
-    eiger_single,
+    detector_single,
     angle_start,
     scanWidth,
     imgWidth,
@@ -183,7 +183,7 @@ def configure_flyer(
     changeState=True,
 ):  # scan encoder 0=x, 1=y,2=z,3=omega
 
-    eiger_single.file.write_path_template = data_directory_name
+    detector_single.file.write_path_template = data_directory_name
 
     yield from bps.mv(vector.sync, 1)
     yield from bps.mv(vector.expose, 1)
@@ -200,7 +200,7 @@ def configure_flyer(
     else:
         yield from bps.mv(vector.buffer_time, 3)
         pass
-    detector_dead_time = eiger_single.cam.dead_time.get()
+    detector_dead_time = detector_single.cam.dead_time.get()
     yield from setup_vector_program(
         vector=vector,
         num_images=numImages,
@@ -233,7 +233,7 @@ def configure_nyx_flyer():
 
 def actual_scan(
     mx_flyer,
-    eiger,
+    detector,
     vector,
     zebra,
     angle_start,
@@ -245,11 +245,11 @@ def actual_scan(
 ):
     # file_prefix = "abc"
     # data_directory_name = "def"
-    yield from bps.mv(eiger.file.external_name, file_prefix)
+    yield from bps.mv(detector.file.external_name, file_prefix)
     yield from configure_flyer(
         vector,
         zebra,
-        eiger,
+        detector,
         angle_start,
         scanWidth,
         imgWidth,
@@ -261,4 +261,4 @@ def actual_scan(
     yield from bp.fly([mx_flyer])
 
 
-# vector, zebra, eiger_single are assumed to be in the namespace already
+# vector, zebra, detector_single are assumed to be in the namespace already

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -35,9 +35,15 @@ class MXFlyer:
     def describe_configuration(self):
         return {}
 
-    def kickoff(self):
-        self.detector.stage()
-        self.vector.go.put(1)
+    def prepare(self, **kwargs): # TODO pass a collection object or parameters here
+        self.detector.prepare(**kwargs) # TODO does this replace stage?
+        self.vector.prepare(**kwargs)
+        self.zebra.prepare(**kwargs)
+
+    def kickoff(self): # TODO assumes that vector needs to be set last - true with our systems
+        self.detector.kickoff()
+        self.zebra.kickoff()
+        self.vector.kickoff()
 
         return NullStatus()
 

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -242,9 +242,10 @@ def actual_scan(
 ):
     # file_prefix = "abc"
     # data_directory_name = "def"
+
     yield from bps.mv(detector.file.external_name, file_prefix)
-    detector_single.file.write_path_template = data_directory_name
-    detector_dead_time = detector_single.cam.dead_time.get()
+    detector.file.write_path_template = data_directory_name
+    detector_dead_time = detector.cam.dead_time.get()
     yield from configure_vector(
         vector,
         angle_start,

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -248,6 +248,7 @@ def actual_scan(
     # file_prefix = "abc"
     # data_directory_name = "def"
     yield from bps.mv(detector.file.external_name, file_prefix)
+    detector_dead_time = detector_single.cam.dead_time.get()
     yield from configure_flyer(
         vector,
         zebra,
@@ -260,6 +261,16 @@ def actual_scan(
         data_directory_name,
         1,
     )
+    yield from configure_zebra(
+        zebra,
+        angle_start,
+        exposurePeriodPerImage,
+        detector_dead_time,
+        scanWidth,
+        imgWidth,
+        numImages
+    }
+
     yield from bp.fly([mx_flyer])
 
 

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -170,7 +170,6 @@ class MXFlyer:
 
 def configure_flyer(
     vector,
-    zebra,
     detector_single,
     angle_start,
     scanWidth,
@@ -251,7 +250,6 @@ def actual_scan(
     detector_dead_time = detector_single.cam.dead_time.get()
     yield from configure_flyer(
         vector,
-        zebra,
         detector,
         angle_start,
         scanWidth,

--- a/mxtools/scans.py
+++ b/mxtools/scans.py
@@ -94,63 +94,6 @@ def setup_vector_program(vector, num_images, angle_start, angle_end, exposure_pe
     yield from bps.mv(vector.hold, 0)
 
 
-def setup_eiger_exposure(eiger, exposure_time, exposure_period):
-    yield from bps.mv(eiger.cam.acquire_time(exposure_time))
-    yield from bps.mv(eiger.cam.acquire_period(exposure_period))
-
-
-def setup_eiger_triggers(eiger, mode, num_triggers, exposure_per_image):
-    yield from bps.mv(eiger.cam.trigger_mode, mode)
-    yield from bps.mv(eiger.cam.num_triggers, num_triggers)
-    yield from bps.mv(eiger.cam.trigger_exposure, exposure_per_image)
-
-
-def setup_eiger_arming(
-    eiger,
-    start,
-    width,
-    num_images,
-    exposure_per_image,
-    file_prefix,
-    data_directory_name,
-    file_number_start,
-    x_beam,
-    y_beam,
-    wavelength,
-    det_distance_m,
-):
-    yield from bps.mv(eiger.cam.trigger_mode, EXTERNAL_SERIES)
-
-    yield from bps.mv(eiger.cam.save_files, 1)
-    yield from bps.mv(eiger.cam.file_owner, getpass.getuser())
-    yield from bps.mv(eiger.cam.file_owner_grp, grp.getgrgid(os.getgid())[0])
-    yield from bps.mv(eiger.cam.file_perms, 420)
-    file_prefix_minus_directory = str(file_prefix)
-    file_prefix_minus_directory = file_prefix_minus_directory.split("/")[-1]
-
-    yield from bps.mv(eiger.cam.acquire_time, exposure_per_image)
-    yield from bps.mv(eiger.cam.acquire_period, exposure_per_image)
-    yield from bps.mv(eiger.cam.num_images, num_images)
-    yield from bps.mv(eiger.cam.file_path, data_directory_name)
-    yield from bps.mv(eiger.cam.fw_name_pattern, f"{file_prefix_minus_directory}_$id")
-
-    # TODO: change it back to eiger.cam.sequence_id once the ophyd PR
-    # https://github.com/bluesky/ophyd/pull/1001 is merged/released.
-    yield from bps.mv(eiger.file.sequence_id, file_number_start)
-
-    # originally from detector_set_fileheader
-    yield from bps.mv(eiger.cam.beam_center_x, x_beam)
-    yield from bps.mv(eiger.cam.beam_center_y, y_beam)
-    yield from bps.mv(eiger.cam.omega_incr, width)
-    yield from bps.mv(eiger.cam.omega_start, start)
-    yield from bps.mv(eiger.cam.wavelength, wavelength)
-    yield from bps.mv(eiger.cam.det_distance, det_distance_m)
-
-    start_arm = time.time()
-    yield from bps.mv(eiger.cam.acquire, 1)
-    logger.info(f"arm time = {time.time() - start_arm}")
-
-
 def setup_eiger_stop_acquire_and_wait(eiger):
     yield from bps.mv(eiger.cam.acquire, 0)
     # wait until Acquire_RBV is 0


### PR DESCRIPTION
make flyer more generic so nyxtools can use the same flyer

- remove beamline-specific code from the MX flyer
- start adding prepare() functions with the goal of having LSDC use the following sequence:
  - flyer.prepare(parameters) # set up and arm all hardwrae
  - flyer.kickoff() # run the flyscan 