### PR TITLE
Set bl specific write path template

### DIFF
--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -78,6 +78,7 @@ class EigerBaseV26(EigerDetector):
         beamline = kwargs.pop("beamline", "fmx")
         super().__init__(*args, **kwargs)
         self.file.write_path_template = f"/nsls2/data/{beamline}/legacy"
+
     def stage(self, *args, **kwargs):
         # before parent
         ret = super().stage(*args, **kwargs)

--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -67,14 +67,17 @@ class EigerBaseV26(EigerDetector):
     file = Cpt(
         EigerSimulatedFilePlugin,
         suffix="cam1:",
-        write_path_template="/nsls2/data/nyx/legacy/",
-        root="/nsls2/data/nyx/legacy",
+        write_path_template="",
     )
     image = Cpt(ImagePlugin, "image1:")
 
     # hotfix: shadow non-existant PV
     size_link = None
 
+    def __init__(self, *args, **kwargs):
+        beamline = kwargs.pop("beamline", "fmx")
+        super().__init__(*args, **kwargs)
+        self.file.write_path_template = f"/nsls2/data/{beamline}/legacy"
     def stage(self, *args, **kwargs):
         # before parent
         ret = super().stage(*args, **kwargs)


### PR DESCRIPTION
set write path template using a beamline placeholder so that it is not hard-coded for a particular beamline

requires changes in LSDC start_bs to send the beamline name when instantiating the detector object - see for example https://github.com/JunAishima/lsdc/blob/04aab714b311e876e4547b1bc0faed3d3d760188/start_bs.py#L111 (will be available in one-branch-to-rule-them-all-rc1)