### PR TITLE
Fix raster 2022 09 29

### DIFF
--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -119,11 +119,10 @@ class MXRasterFlyer(MXFlyer):
 
     def collect(self):
         logger.debug("raster_flyer.collect(): going to unstage now")
-        super().unstage()
         yield {"data": {}, "timestamps": {}, "time": 0, "seq_num": 0}
 
     def unstage(self):
-        super().unstage()
+        pass
 
     def collect_asset_docs(self):  # not to be done here
         for _ in ():

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -53,7 +53,7 @@ class MXRasterFlyer(MXFlyer):
         if is_still is False:
             self.zebra.pc.gate.width.put(gate_width)
             self.zebra.pc.gate.step.put(scan_width)
-        self.zebra.pc.gate.num_gates.put(num_images)
+        self.zebra.pc.gate.num_gates.put(1)
         self.zebra.pc.pulse.start.put(0)
         self.zebra.pc.pulse.width.put(pulse_width)
         self.zebra.pc.pulse.step.put(pulse_step)


### PR DESCRIPTION
fixes to allow raster to work correctly

before these fixes, there were the following issues:
* each row did not look like the correct number of images - mis-registering of rows, so that the heat map looks rather random
* on the second raster, Bluesky would complain that the detector was being re-staged