### PR TITLE
Fix raster 2022 11

### DIFF
--- a/mxtools/eiger.py
+++ b/mxtools/eiger.py
@@ -287,6 +287,9 @@ class EigerSingleTriggerV26(SingleTrigger, EigerBaseV26):
             ret = super().describe(*args, **kwargs)
             return ret
 
+    def super_unstage(self):
+        super().unstage()
+
 
 def set_eiger_defaults(eiger):
     """Choose which attributes to read per-step (read_attrs) or

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -233,7 +233,7 @@ class MXFlyer:
         self.setup_zebra_vector_scan(
             angle_start=angle_start,
             gate_width=GW,
-            scan_width=scanWidth,
+            scan_width=scanWidth + 0.001,  # JA not sure why, but done in old LSDC
             pulse_width=PW,
             pulse_step=PS,
             exposure_period_per_image=exposurePeriodPerImage,

--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -186,6 +186,7 @@ class MXFlyer:
         scanWidth = kwargs["scan_width"]
         imgWidth = kwargs["img_width"]
         exposurePeriodPerImage = kwargs["exposure_period_per_image"]
+        protocol = kwargs.get("protocol", "standard")
         x_um = (kwargs["x_start_um"], kwargs["x_end_um"])
         y_um = (kwargs["y_start_um"], kwargs["y_end_um"])
         z_um = (kwargs["z_start_um"], kwargs["z_end_um"])
@@ -202,11 +203,10 @@ class MXFlyer:
             angle_end = angle_start + scanWidth
             numImages = int(round(scanWidth / imgWidth))
         total_exposure_time = exposurePeriodPerImage * numImages
-        if total_exposure_time < 1.0:
+        if total_exposure_time < 1.0 and protocol != "raster":
             self.vector.buffer_time.put(1000)
         else:
             self.vector.buffer_time.put(3)
-            pass
         self.setup_vector_program(
             num_images=numImages,
             angle_start=angle_start,

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -24,8 +24,13 @@ class MXRasterFlyer(MXFlyer):
         return NullStatus()
 
     def update_parameters(self, *args, **kwargs):
+        row_index = kwargs.get("row_index", 0)
+        num_images = kwargs["num_images"]
+        if row_index > 0:
+            self.configure_zebra(**kwargs)
+        else:
+            self.zebra.pc.pulse.max.put(num_images)
         self.configure_vector(**kwargs)
-        self.configure_zebra(**kwargs)
 
     def configure_detector(self, **kwargs):
         file_prefix = kwargs["file_prefix"]

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -28,33 +28,13 @@ class MXRasterFlyer(MXFlyer):
         self.configure_vector(**kwargs)
         row_index = kwargs.get("row_index", 0)
         num_images = kwargs["num_images"]
-        print(f'row_index: {row_index}')
         if row_index == 0:
-            print('configuring zebra')
+            print('row 0: fully configuring zebra')
             self.configure_zebra(**kwargs)
         else:
-            angle_start = kwargs["angle_start"]
-            exposurePeriodPerImage = kwargs["exposure_period_per_image"]
-            detector_dead_time = kwargs["detector_dead_time"]
-            scanWidth = kwargs["scan_width"]
-            imgWidth = kwargs["img_width"]
             numImages = kwargs["num_images"]
-
-            PW = (exposurePeriodPerImage - detector_dead_time) * 1000
-            PS = (exposurePeriodPerImage) * 1000
-            GW = scanWidth - (1.0 - (PW / PS)) * (imgWidth / 2.0)
-            self.setup_zebra_vector_scan(
-                angle_start=angle_start,
-                gate_width=GW,
-                scan_width=scanWidth,
-                pulse_width=PW,
-                pulse_step=PS,
-                exposure_period_per_image=exposurePeriodPerImage,
-                num_images=numImages,
-                is_still=imgWidth == 0,
-            )
-            print('just setting pulse max')
-            print(f'num_gates: {self.zebra.pc.gate.num_gates.get()}')
+            logger.info(f'row {row_index}: only setting pulse max')
+            self.zebra.pulse.max.put(numImages)
         logger.info('finished updating parameters')
 
     def configure_detector(self, **kwargs):

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -24,13 +24,38 @@ class MXRasterFlyer(MXFlyer):
         return NullStatus()
 
     def update_parameters(self, *args, **kwargs):
+        logger.info('starting updating parameters')
+        self.configure_vector(**kwargs)
         row_index = kwargs.get("row_index", 0)
         num_images = kwargs["num_images"]
-        if row_index > 0:
+        print(f'row_index: {row_index}')
+        if row_index == 0:
+            print('configuring zebra')
             self.configure_zebra(**kwargs)
         else:
-            self.zebra.pc.pulse.max.put(num_images)
-        self.configure_vector(**kwargs)
+            angle_start = kwargs["angle_start"]
+            exposurePeriodPerImage = kwargs["exposure_period_per_image"]
+            detector_dead_time = kwargs["detector_dead_time"]
+            scanWidth = kwargs["scan_width"]
+            imgWidth = kwargs["img_width"]
+            numImages = kwargs["num_images"]
+
+            PW = (exposurePeriodPerImage - detector_dead_time) * 1000
+            PS = (exposurePeriodPerImage) * 1000
+            GW = scanWidth - (1.0 - (PW / PS)) * (imgWidth / 2.0)
+            self.setup_zebra_vector_scan(
+                angle_start=angle_start,
+                gate_width=GW,
+                scan_width=scanWidth,
+                pulse_width=PW,
+                pulse_step=PS,
+                exposure_period_per_image=exposurePeriodPerImage,
+                num_images=numImages,
+                is_still=imgWidth == 0,
+            )
+            print('just setting pulse max')
+            print(f'num_gates: {self.zebra.pc.gate.num_gates.get()}')
+        logger.info('finished updating parameters')
 
     def configure_detector(self, **kwargs):
         file_prefix = kwargs["file_prefix"]

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -24,17 +24,17 @@ class MXRasterFlyer(MXFlyer):
         return NullStatus()
 
     def update_parameters(self, *args, **kwargs):
-        logger.info("starting updating parameters")
+        logger.debug("starting updating parameters")
         self.configure_vector(**kwargs)
         row_index = kwargs.get("row_index", 0)
         if row_index == 0:
-            print("row 0: fully configuring zebra")
+            logger.debug("row 0: fully configuring zebra")
             self.configure_zebra(**kwargs)
         else:
             numImages = kwargs["num_images"]
-            logger.info(f"row {row_index}: only setting pulse max")
+            logger.debug(f"row {row_index}: only setting pulse max")
             self.zebra.pulse.max.put(numImages)
-        logger.info("finished updating parameters")
+        logger.debug("finished updating parameters")
 
     def configure_detector(self, **kwargs):
         file_prefix = kwargs["file_prefix"]

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -24,18 +24,17 @@ class MXRasterFlyer(MXFlyer):
         return NullStatus()
 
     def update_parameters(self, *args, **kwargs):
-        logger.info('starting updating parameters')
+        logger.info("starting updating parameters")
         self.configure_vector(**kwargs)
         row_index = kwargs.get("row_index", 0)
-        num_images = kwargs["num_images"]
         if row_index == 0:
-            print('row 0: fully configuring zebra')
+            print("row 0: fully configuring zebra")
             self.configure_zebra(**kwargs)
         else:
             numImages = kwargs["num_images"]
-            logger.info(f'row {row_index}: only setting pulse max')
+            logger.info(f"row {row_index}: only setting pulse max")
             self.zebra.pulse.max.put(numImages)
-        logger.info('finished updating parameters')
+        logger.info("finished updating parameters")
 
     def configure_detector(self, **kwargs):
         file_prefix = kwargs["file_prefix"]


### PR DESCRIPTION
fix a few issues that we had with rasters that were fixed recently

- slow rastering - removed resetting per row (typically done with the vector program)
- unstaging detector
- fix zebra gate step - necessary to get the correct number of images per row
- fix vector buffer time for raster vectors - should be the same 3 ms as for short standard vectors