### PR TITLE
make sleeps associated with zebra_daq_prep shorter

### DIFF
--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -228,7 +228,7 @@ class MXFlyer:
         imgWidth = kwargs["img_width"]
         numImages = kwargs["num_images"]
         self.zebra_daq_prep()
-        ttime.sleep(1.0)
+        ttime.sleep(0.5)
 
         PW = (exposurePeriodPerImage - detector_dead_time) * 1000
         PS = (exposurePeriodPerImage) * 1000
@@ -313,7 +313,7 @@ class MXFlyer:
 
     def zebra_daq_prep(self):
         self.zebra.reset.put(1)
-        ttime.sleep(2.0)  # not known why this sleep is so long (done since LSDC 1)
+        ttime.sleep(0.5)  # not known why this sleep is so long (done since LSDC 1)
         self.zebra.out1.put(31)
         self.zebra.m1_set_pos.put(1)
         self.zebra.m2_set_pos.put(1)

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -51,7 +51,7 @@ class MXRasterFlyer(MXFlyer):
         numImages = kwargs["num_images"]
         self.zebra_daq_prep()
         self.zebra.pc.encoder.put(3)  # encoder 0=x, 1=y,2=z,3=omega
-        ttime.sleep(1.0)  # used since LSDC 1 - reason unknown
+        ttime.sleep(0.5)  # used since LSDC 1 - reason unknown
         self.zebra.pc.direction.put(0)  # direction 0 = positive
         self.zebra.pc.gate.sel.put(0)
         self.zebra.pc.pulse.sel.put(1)


### PR DESCRIPTION
 * one of the sleeps is immediately after resetting - Stu Myers says we should be able to shorten this to 0.5 sec
 * the other is after the zebra_daq_prep block - originally 1 sec, shortened to 0.5 sec as well