### PR TITLE
Enable raster flyer to save asset data

### DIFF
--- a/mxtools/flyer.py
+++ b/mxtools/flyer.py
@@ -93,14 +93,6 @@ class MXFlyer:
             "filled": {key: False for key in data},
         }
 
-    # def collect_asset_docs(self):
-    #     # items = list(self._asset_docs_cache)
-    #     items = list(self.detector.file._asset_docs_cache)
-    #     print(f"{print_now()} items:\n{items}")
-    #     self.detector.file._asset_docs_cache.clear()
-    #     for item in items:
-    #         yield item
-
     def collect_asset_docs(self):
         asset_docs_cache = []
 
@@ -241,17 +233,41 @@ class MXFlyer:
         )
 
     def detector_arm(self, **kwargs):
-        start = kwargs["angle_start"]
-        width = kwargs["img_width"]
-        num_images = kwargs["num_images"]
-        exposure_per_image = kwargs["exposure_period_per_image"]
-        file_prefix = kwargs["file_prefix"]
-        data_directory_name = kwargs["data_directory_name"]
-        file_number_start = kwargs["file_number_start"]
-        x_beam = kwargs["x_beam"]
-        y_beam = kwargs["y_beam"]
-        wavelength = kwargs["wavelength"]
-        det_distance_m = kwargs["det_distance_m"]
+        return self._arm_detector(
+            start=kwargs["angle_start"],
+            width=kwargs["img_width"],
+            exposure_per_image=kwargs["exposure_period_per_image"],
+            file_prefix=kwargs["file_prefix"],
+            data_directory_name=kwargs["data_directory_name"],
+            file_number_start=kwargs["file_number_start"],
+            x_beam=kwargs["x_beam"],
+            y_beam=kwargs["y_beam"],
+            wavelength=kwargs["wavelength"],
+            det_distance_m=kwargs["det_distance_m"],
+            trigger_mode=eiger.EXTERNAL_SERIES,
+            num_triggers=1,
+            num_images=kwargs["num_images"],
+            num_images_per_file=500,
+        )
+
+    def _arm_detector(
+        self,
+        *,
+        start,
+        width,
+        exposure_per_image,
+        file_prefix,
+        data_directory_name,
+        file_number_start,
+        x_beam,
+        y_beam,
+        wavelength,
+        det_distance_m,
+        trigger_mode,
+        num_triggers,
+        num_images=None,
+        num_images_per_file=500,
+    ):
 
         self.detector.cam.save_files.put(1)
         self.detector.cam.file_owner.put(getpass.getuser())
@@ -263,9 +279,10 @@ class MXFlyer:
         self.detector.cam.acquire_time.put(exposure_per_image)
         self.detector.cam.acquire_period.put(exposure_per_image)
         # Trigger mode set before num_images due to updates in Eiger REST API
-        self.detector.cam.trigger_mode.put(eiger.EXTERNAL_SERIES)
-        self.detector.cam.num_images.put(num_images)
-        self.detector.cam.num_triggers.put(1)
+        self.detector.cam.trigger_mode.put(trigger_mode)
+        if num_images is not None:
+            self.detector.cam.num_images.put(num_images)
+        self.detector.cam.num_triggers.put(num_triggers)
         self.detector.cam.file_path.put(data_directory_name)
         self.detector.cam.fw_name_pattern.put(f"{file_prefix_minus_directory}_$id")
 
@@ -279,7 +296,7 @@ class MXFlyer:
         self.detector.cam.wavelength.put(wavelength)
         self.detector.cam.det_distance.put(det_distance_m)
 
-        self.detector.file.file_write_images_per_file.put(500)
+        self.detector.file.file_write_images_per_file.put(num_images_per_file)
 
         def armed_callback(value, old_value, **kwargs):
             if old_value == 0 and value == 1:

--- a/mxtools/governor.py
+++ b/mxtools/governor.py
@@ -1,90 +1,89 @@
 """
-    Rationale:
+Rationale:
 
-    The Governor is a dynamic beast. The PVs it exposes depend
-    on the configuration files given to it. Therefore, it would be
-    hopelessly tedious to manually keep a Governor ophyd object in
-    sync with the Governor IOC. There are at least two solutions to
-    this issue:
+The Governor is a dynamic beast. The PVs it exposes depend
+on the configuration files given to it. Therefore, it would be
+hopelessly tedious to manually keep a Governor ophyd object in
+sync with the Governor IOC. There are at least two solutions to
+this issue:
 
-    1. Have the IOC auto-generate Governor ohpyd objects
+1. Have the IOC auto-generate Governor ohpyd objects
 
-    This would require the IOC to produce a Python file (perhaps via
-    Jinja) and then to, somehow, synchronize this file with the rest
-    of the startup files for the beamline.
+This would require the IOC to produce a Python file (perhaps via
+Jinja) and then to, somehow, synchronize this file with the rest
+of the startup files for the beamline.
 
-    2. Have the ophyd object be dynamically generated at startup time
+2. Have the ophyd object be dynamically generated at startup time
 
-    No modifications to the IOC would be required, as long as the IOC
-    exports enough metadata. The downside of this approach is that
-    there is some encapsulation leakage (direct cagets) and there's
-    a risk that the Governor IOC won't be up when this function runs.
+No modifications to the IOC would be required, as long as the IOC
+exports enough metadata. The downside of this approach is that
+there is some encapsulation leakage (direct cagets) and there's
+a risk that the Governor IOC won't be up when this function runs.
 
-    We take approach #2 here, with the hope that the benefits will
-    outweight the drawbacks.
+We take approach #2 here, with the hope that the benefits will
+outweight the drawbacks.
 
-    NOTE: given that the Governor ophyd object is created dynamically,
-    the Governor IOC *must be running* when this file runs.
+NOTE: given that the Governor ophyd object is created dynamically,
+the Governor IOC *must be running* when this file runs.
 
-    The overall available auto-generated API will be as follows
-    (all leafs are EpicsSignals):
+The overall available auto-generated API will be as follows
+(all leafs are EpicsSignals):
 
-    govs = _make_governors('XF:19IDC-ES', name='govs')
+govs = _make_governors('XF:19IDC-ES', name='govs')
 
-    #
-    # Global Governor control
-    #
+#
+# Global Governor control
+#
 
-    # Controls whether any Governor is active or not:
-    govs.sel.active
+# Controls whether any Governor is active or not:
+govs.sel.active
 
-    # Selects which Governor to use ("Human", "Robot"):
-    govs.sel.config
+# Selects which Governor to use ("Human", "Robot"):
+govs.sel.config
 
-    # Alias for the Robot configuration
-    gov_rbt = govs.gov.Robot
+# Alias for the Robot configuration
+gov_rbt = govs.gov.Robot
 
-    #
-    # Meta-data
-    #
+#
+# Meta-data
+#
 
-    # Current state
-    gov_rbt.state
+# Current state
+gov_rbt.state
 
-    # All existing states
-    gov_rbt.states
+# All existing states
+gov_rbt.states
 
-    # All existing devices
-    gov_rbt.devices
+# All existing devices
+gov_rbt.devices
 
-    # All currently reachable states
-    gov_rbt.reachable
+# All currently reachable states
+gov_rbt.reachable
 
-    # All targets of the device "bsy"
-    gov_rbt.dev.bsy.targets
+# All targets of the device "bsy"
+gov_rbt.dev.bsy.targets
 
-    #
-    # Per-device configuration
-    #
+#
+# Per-device configuration
+#
 
-    # Position for target "Down" of device "bsy"
-    gov_rbt.dev.bsy.target_Down
+# Position for target "Down" of device "bsy"
+gov_rbt.dev.bsy.target_Down
 
-    # Low limit of device "bsy" when at state "SE"
-    gov_rbt.dev.bsy.at_SE.low
+# Low limit of device "bsy" when at state "SE"
+gov_rbt.dev.bsy.at_SE.low
 
-    # Pos for high limit of device "bsy" when at state "SE":
-    gov_rbt.dev.bsy.at_SE.high
+# Pos for high limit of device "bsy" when at state "SE":
+gov_rbt.dev.bsy.at_SE.high
 
-    #
-    # Changing state
-    #
+#
+# Changing state
+#
 
-    # Attempt to move the Governor to the SE state
-    # (behaves as a positioner)
-    RE(bps.abs_set(gov_rbt, 'SE', wait=True))
+# Attempt to move the Governor to the SE state
+# (behaves as a positioner)
+RE(bps.abs_set(gov_rbt, 'SE', wait=True))
 """
-
 
 from typing import Dict, List
 

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -114,5 +114,3 @@ class MXRasterFlyer(MXFlyer):
             num_images=None,
             num_images_per_file=kwargs["num_images_per_file"],
         )
-
-

--- a/mxtools/raster_flyer.py
+++ b/mxtools/raster_flyer.py
@@ -1,11 +1,7 @@
-import getpass
-import grp
 import logging
-import os
 import time as ttime
 
 from ophyd.sim import NullStatus
-from ophyd.status import SubscriptionStatus
 
 from . import eiger
 from .flyer import MXFlyer
@@ -35,12 +31,6 @@ class MXRasterFlyer(MXFlyer):
             logger.debug(f"row {row_index}: only setting pulse max")
             self.zebra.pc.pulse.max.put(numImages)
         logger.debug("finished updating parameters")
-
-    def configure_detector(self, **kwargs):
-        file_prefix = kwargs["file_prefix"]
-        data_directory_name = kwargs["data_directory_name"]
-        self.detector.file.external_name.put(file_prefix)
-        self.detector.file.write_path_template = data_directory_name
 
     def configure_zebra(self, **kwargs):
         angle_start = kwargs["angle_start"]
@@ -108,67 +98,21 @@ class MXRasterFlyer(MXFlyer):
         # exposure time change
 
     def detector_arm(self, **kwargs):
-        start = kwargs["angle_start"]
-        width = kwargs["img_width"]
-        total_num_images = kwargs["total_num_images"]
-        exposure_per_image = kwargs["exposure_period_per_image"]
-        file_prefix = kwargs["file_prefix"]
-        data_directory_name = kwargs["data_directory_name"]
-        file_number_start = kwargs["file_number_start"]
-        x_beam = kwargs["x_beam"]
-        y_beam = kwargs["y_beam"]
-        wavelength = kwargs["wavelength"]
-        det_distance_m = kwargs["det_distance_m"]
-        num_images_per_file = kwargs["num_images_per_file"]
+        return self._arm_detector(
+            start=kwargs["angle_start"],
+            width=kwargs["img_width"],
+            exposure_per_image=kwargs["exposure_period_per_image"],
+            file_prefix=kwargs["file_prefix"],
+            data_directory_name=kwargs["data_directory_name"],
+            file_number_start=kwargs["file_number_start"],
+            x_beam=kwargs["x_beam"],
+            y_beam=kwargs["y_beam"],
+            wavelength=kwargs["wavelength"],
+            det_distance_m=kwargs["det_distance_m"],
+            trigger_mode=eiger.EXTERNAL_ENABLE,
+            num_triggers=kwargs["total_num_images"],
+            num_images=None,
+            num_images_per_file=kwargs["num_images_per_file"],
+        )
 
-        self.detector.cam.save_files.put(1)
-        self.detector.cam.file_owner.put(getpass.getuser())
-        self.detector.cam.file_owner_grp.put(grp.getgrgid(os.getgid())[0])
-        self.detector.cam.file_perms.put(420)
-        file_prefix_minus_directory = str(file_prefix)
-        file_prefix_minus_directory = file_prefix_minus_directory.split("/")[-1]
 
-        self.detector.cam.acquire_time.put(exposure_per_image)
-        self.detector.cam.acquire_period.put(exposure_per_image)
-        # Setting trigger mode before num_triggers due to change in Eiger REST API change
-        self.detector.cam.trigger_mode.put(eiger.EXTERNAL_ENABLE)
-        self.detector.cam.num_triggers.put(total_num_images)
-        self.detector.cam.file_path.put(data_directory_name)
-        self.detector.cam.fw_name_pattern.put(f"{file_prefix_minus_directory}_$id")
-
-        self.detector.cam.sequence_id.put(file_number_start)
-
-        # originally from detector_set_fileheader
-        self.detector.cam.beam_center_x.put(x_beam)
-        self.detector.cam.beam_center_y.put(y_beam)
-        self.detector.cam.omega_incr.put(width)
-        self.detector.cam.omega_start.put(start)
-        self.detector.cam.wavelength.put(wavelength)
-        self.detector.cam.det_distance.put(det_distance_m)
-
-        self.detector.file.file_write_images_per_file.put(num_images_per_file)
-
-        def armed_callback(value, old_value, **kwargs):
-            if old_value == 0 and value == 1:
-                return True
-            return False
-
-        status = SubscriptionStatus(self.detector.cam.armed, armed_callback, run=False)
-
-        self.detector.cam.acquire.put(1)
-
-        return status
-
-    def describe_collect(self):
-        return {"stream_name": {}}
-
-    def collect(self):
-        logger.debug("raster_flyer.collect(): going to unstage now")
-        yield {"data": {}, "timestamps": {}, "time": 0, "seq_num": 0}
-
-    def unstage(self):
-        pass
-
-    def collect_asset_docs(self):  # not to be done here
-        for _ in ():
-            yield _

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,7 @@ This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
 Upgrade pip like so:
 
 pip install --upgrade pip
-""".format(
-        *(sys.version_info[:2] + min_version)
-    )
+""".format(*(sys.version_info[:2] + min_version))
     sys.exit(error)
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This pull request refactors the detector arming logic in both `mxtools/flyer.py` and `mxtools/raster_flyer.py` to centralize and simplify the configuration of detector parameters. The main changes involve moving repeated logic into a new private method, improving maintainability and consistency between classes, and cleaning up unused or redundant code.

Refactoring and centralization of detector arming logic:

* Introduced a new `_arm_detector` method in `MXFlyer` to handle all detector arming and configuration, consolidating logic that was previously duplicated across methods. The `detector_arm` methods in both `MXFlyer` and `RasterFlyer` now delegate to this shared function, passing the appropriate parameters. [[1]](diffhunk://#diff-8b3728a72556e60d920f8f996425865baefa7c06df01d7e6bf0a90feac074c30L244-R270) [[2]](diffhunk://#diff-8b3728a72556e60d920f8f996425865baefa7c06df01d7e6bf0a90feac074c30L266-R285) [[3]](diffhunk://#diff-8b3728a72556e60d920f8f996425865baefa7c06df01d7e6bf0a90feac074c30L282-R299) [[4]](diffhunk://#diff-ceddb05929c26d70099cbb3ef969c1dd9e5257aea723c79b3d8492c8a8ae14ffL111-L174)

Code cleanup and removal of unused code:

* Removed commented-out and unused methods such as the old `collect_asset_docs` implementation and the `configure_detector` method in `RasterFlyer`, as well as redundant imports. [[1]](diffhunk://#diff-8b3728a72556e60d920f8f996425865baefa7c06df01d7e6bf0a90feac074c30L96-L103) [[2]](diffhunk://#diff-ceddb05929c26d70099cbb3ef969c1dd9e5257aea723c79b3d8492c8a8ae14ffL1-L8) [[3]](diffhunk://#diff-ceddb05929c26d70099cbb3ef969c1dd9e5257aea723c79b3d8492c8a8ae14ffL39-L44) [[4]](diffhunk://#diff-ceddb05929c26d70099cbb3ef969c1dd9e5257aea723c79b3d8492c8a8ae14ffL111-L174)

These changes make the detector configuration process more robust and easier to maintain by reducing code duplication and clarifying the flow of parameter handling.